### PR TITLE
Compile Time Mismatch Errors & centerAnchors

### DIFF
--- a/Anchorage.swift
+++ b/Anchorage.swift
@@ -41,261 +41,261 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
 
     // MARK: - Equality Constraints
 
-@discardableResult public func == (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(equalToConstant: rhs))
-}
-
-@discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(equalTo: rhs))
-}
-
-@discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(equalTo: rhs))
-}
-
-@discardableResult public func == (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(equalTo: rhs))
-}
-
-@discardableResult public func == <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func == <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func == <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func == (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
-    if let anchor = rhs.anchor {
-        return activate(constraint: lhs.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    @discardableResult public func == (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(equalToConstant: rhs))
     }
-    else {
-        return activate(constraint: lhs.constraint(equalToConstant: rhs.constant), withPriority: rhs.priority)
+
+    @discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(equalTo: rhs))
     }
-}
 
-@discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activate(constraintsEqualTo: rhs)
-}
-
-@discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-}
-
-@discardableResult public func == <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-    return lhs.activate(constraintsEqualTo: rhs)
-}
-
-@discardableResult public func == <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-    return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-}
-
-// MARK: - Inequality Constraints
-
-@discardableResult public func <= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs))
-}
-
-@discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
-}
-
-@discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
-}
-
-@discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
-}
-
-@discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func <= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
-    if let anchor = rhs.anchor {
-        return activate(constraint: lhs.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    @discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(equalTo: rhs))
     }
-    else {
-        return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+
+    @discardableResult public func == (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(equalTo: rhs))
     }
-}
 
-@discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activate(constraintsLessThanOrEqualTo: rhs)
-}
-
-@discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-}
-
-@discardableResult public func <= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-    return lhs.activate(constraintsLessThanOrEqualTo: rhs)
-}
-
-@discardableResult public func <= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-    return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-}
-
-@discardableResult public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs))
-}
-
-@discardableResult public func >=<T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
-}
-
-@discardableResult public func >=<T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
-}
-
-@discardableResult public func >=<T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
-}
-
-@discardableResult public func >= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func >= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func >= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-}
-
-@discardableResult public func >= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
-    if let anchor = rhs.anchor {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+    @discardableResult public func == <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
     }
-    else {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+
+    @discardableResult public func == <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
     }
-}
 
-@discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
-}
+    @discardableResult public func == <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    }
 
-@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-}
+    @discardableResult public func == (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
+        if let anchor = rhs.anchor {
+            return activate(constraint: lhs.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        }
+        else {
+            return activate(constraint: lhs.constraint(equalToConstant: rhs.constant), withPriority: rhs.priority)
+        }
+    }
 
-@discardableResult public func >= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
-}
+    @discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs)
+    }
 
-@discardableResult public func >= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-}
+    @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
 
-// MARK: - Priority
+    @discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs)
+    }
 
-precedencegroup PriorityPrecedence {
-    associativity: none
-    higherThan: ComparisonPrecedence
-}
+    @discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
 
-infix operator ~: PriorityPrecedence
+    // MARK: - Inequality Constraints
 
-@discardableResult public func ~ (lhs: CGFloat, rhs: UILayoutPriority) -> LayoutExpression<NSLayoutDimension> {
-    return LayoutExpression(constant: lhs, priority: rhs)
-}
+    @discardableResult public func <= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs))
+    }
 
-@discardableResult public func ~ <T: LayoutAnchorType>(lhs: T, rhs: UILayoutPriority) -> LayoutExpression<T> {
-    return LayoutExpression(anchor: lhs, priority: rhs)
-}
+    @discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
+    }
 
-@discardableResult public func ~ <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: UILayoutPriority) -> LayoutExpression<T> {
-    var expr = lhs
-    expr.priority = rhs
-    return expr
-}
+    @discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
+    }
 
-// MARK: Layout Expressions
+    @discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
+    }
 
-@discardableResult public func * (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-    return LayoutExpression(anchor: lhs, multiplier: rhs)
-}
+    @discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    }
 
-@discardableResult public func * (lhs: CGFloat, rhs: NSLayoutDimension) -> LayoutExpression<NSLayoutDimension> {
-    return LayoutExpression(anchor: rhs, multiplier: lhs)
-}
+    @discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    }
 
-@discardableResult public func * (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-    var expr = lhs
-    expr.multiplier *= rhs
-    return expr
-}
+    @discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    }
 
-@discardableResult public func * (lhs: CGFloat, rhs: LayoutExpression<NSLayoutDimension>) -> LayoutExpression<NSLayoutDimension> {
-    var expr = rhs
-    expr.multiplier *= lhs
-    return expr
-}
+    @discardableResult public func <= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
+        if let anchor = rhs.anchor {
+            return activate(constraint: lhs.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        }
+        else {
+            return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+        }
+    }
 
-@discardableResult public func / (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-    return LayoutExpression(anchor: lhs, multiplier: 1.0 / rhs)
-}
+    @discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+    }
 
-@discardableResult public func / (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-    var expr = lhs
-    expr.multiplier /= rhs
-    return expr
-}
+    @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
 
-@discardableResult public func + <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
-    return LayoutExpression(anchor: lhs, constant: rhs)
-}
+    @discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+    }
 
-@discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
-    return LayoutExpression(anchor: rhs, constant: lhs)
-}
+    @discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
 
-@discardableResult public func + <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
-    var expr = lhs
-    expr.constant += rhs
-    return expr
-}
+    @discardableResult public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs))
+    }
 
-@discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
-    var expr = rhs
-    expr.constant += lhs
-    return expr
-}
+    @discardableResult public func >=<T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
+    }
 
-@discardableResult public func - <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
-    return LayoutExpression(anchor: lhs, constant: -rhs)
-}
+    @discardableResult public func >=<T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
+    }
 
-@discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
-    return LayoutExpression(anchor: rhs, constant: -lhs)
-}
+    @discardableResult public func >=<T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
+    }
 
-@discardableResult public func - <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
-    var expr = lhs
-    expr.constant -= rhs
-    return expr
-}
+    @discardableResult public func >= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    }
 
-@discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
-    var expr = rhs
-    expr.constant -= lhs
-    return expr
-}
+    @discardableResult public func >= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    }
+
+    @discardableResult public func >= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    }
+
+    @discardableResult public func >= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
+        if let anchor = rhs.anchor {
+            return activate(constraint: lhs.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
+        }
+        else {
+            return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
+        }
+    }
+
+    @discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+    }
+
+    @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    @discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+    }
+
+    @discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    // MARK: - Priority
+
+    precedencegroup PriorityPrecedence {
+        associativity: none
+        higherThan: ComparisonPrecedence
+    }
+
+    infix operator ~: PriorityPrecedence
+
+    @discardableResult public func ~ (lhs: CGFloat, rhs: UILayoutPriority) -> LayoutExpression<NSLayoutDimension> {
+        return LayoutExpression(constant: lhs, priority: rhs)
+    }
+
+    @discardableResult public func ~ <T: LayoutAnchorType>(lhs: T, rhs: UILayoutPriority) -> LayoutExpression<T> {
+        return LayoutExpression(anchor: lhs, priority: rhs)
+    }
+
+    @discardableResult public func ~ <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: UILayoutPriority) -> LayoutExpression<T> {
+        var expr = lhs
+        expr.priority = rhs
+        return expr
+    }
+
+    // MARK: Layout Expressions
+
+    @discardableResult public func * (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+        return LayoutExpression(anchor: lhs, multiplier: rhs)
+    }
+
+    @discardableResult public func * (lhs: CGFloat, rhs: NSLayoutDimension) -> LayoutExpression<NSLayoutDimension> {
+        return LayoutExpression(anchor: rhs, multiplier: lhs)
+    }
+
+    @discardableResult public func * (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+        var expr = lhs
+        expr.multiplier *= rhs
+        return expr
+    }
+
+    @discardableResult public func * (lhs: CGFloat, rhs: LayoutExpression<NSLayoutDimension>) -> LayoutExpression<NSLayoutDimension> {
+        var expr = rhs
+        expr.multiplier *= lhs
+        return expr
+    }
+
+    @discardableResult public func / (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+        return LayoutExpression(anchor: lhs, multiplier: 1.0 / rhs)
+    }
+
+    @discardableResult public func / (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+        var expr = lhs
+        expr.multiplier /= rhs
+        return expr
+    }
+
+    @discardableResult public func + <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
+        return LayoutExpression(anchor: lhs, constant: rhs)
+    }
+
+    @discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
+        return LayoutExpression(anchor: rhs, constant: lhs)
+    }
+
+    @discardableResult public func + <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
+        var expr = lhs
+        expr.constant += rhs
+        return expr
+    }
+
+    @discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
+        var expr = rhs
+        expr.constant += lhs
+        return expr
+    }
+
+    @discardableResult public func - <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
+        return LayoutExpression(anchor: lhs, constant: -rhs)
+    }
+
+    @discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
+        return LayoutExpression(anchor: rhs, constant: -lhs)
+    }
+
+    @discardableResult public func - <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
+        var expr = lhs
+        expr.constant -= rhs
+        return expr
+    }
+
+    @discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
+        var expr = rhs
+        expr.constant -= lhs
+        return expr
+    }
 
 #endif
 
@@ -319,8 +319,9 @@ public struct LayoutExpression<T : LayoutAnchorType> {
 
 public protocol AnchorGroupProvider {
 
-    var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> { get }
-    var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> { get }
+    var horizontalAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor> { get }
+    var verticalAnchors: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor> { get }
+    var centerAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutYAxisAnchor> { get }
 
 }
 
@@ -335,205 +336,165 @@ extension AnchorGroupProvider {
 
 extension UIView: AnchorGroupProvider {
 
-    public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
-        return AxisAnchors(top: nil, leading: leadingAnchor, bottom: nil, trailing: trailingAnchor)
+    public var horizontalAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor> {
+        return AnchorPair(first: leadingAnchor, second: trailingAnchor)
     }
-    public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
-        return AxisAnchors(top: topAnchor, leading: nil, bottom: bottomAnchor, trailing: nil)
+    public var verticalAnchors: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor> {
+        return AnchorPair(first: topAnchor, second: bottomAnchor)
+    }
+    public var centerAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutYAxisAnchor> {
+        return AnchorPair(first: centerXAnchor, second: centerYAnchor)
     }
 
 }
 
 extension UIViewController: AnchorGroupProvider {
 
-    public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
-        return AxisAnchors(top: nil, leading: view.leadingAnchor, bottom: nil, trailing: view.trailingAnchor)
+    public var horizontalAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor> {
+        return AnchorPair(first: view.leadingAnchor, second: view.trailingAnchor)
     }
-    public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
-        return AxisAnchors(top: topLayoutGuide.bottomAnchor, leading: nil, bottom: bottomLayoutGuide.topAnchor, trailing: nil)
+    public var verticalAnchors: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor> {
+        return AnchorPair(first: topLayoutGuide.bottomAnchor, second: bottomLayoutGuide.topAnchor)
+    }
+    public var centerAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutYAxisAnchor> {
+        return AnchorPair(first: view.centerXAnchor, second: view.centerYAnchor)
     }
 
 }
 
 extension UILayoutGuide: AnchorGroupProvider {
 
-    public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
-        return AxisAnchors(top: nil, leading: leadingAnchor, bottom: nil, trailing: trailingAnchor)
+    public var horizontalAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor> {
+        return AnchorPair(first: leadingAnchor, second: trailingAnchor)
     }
-    public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
-        return AxisAnchors(top: topAnchor, leading: nil, bottom: bottomAnchor, trailing: nil)
+    public var verticalAnchors: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor> {
+        return AnchorPair(first: topAnchor, second: bottomAnchor)
     }
-    
-}
-
-// MARK: - LayoutEdge
-
-enum LayoutEdge {
-
-    case top, leading, bottom, trailing
-    static let Horizontal = [leading, trailing]
-    static let Vertical = [top, bottom]
-    static let All = [top, leading, bottom, trailing]
-
-    var axis: UILayoutConstraintAxis {
-        switch self {
-        case .top, .bottom:
-            return .vertical
-        case .leading, .trailing:
-            return .horizontal
-        }
-    }
-
-    func transform(constant theConstant: CGFloat) -> CGFloat {
-        switch self {
-        case .top, .leading:
-            return theConstant
-        case .bottom, .trailing:
-            return -theConstant
-        }
+    public var centerAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutYAxisAnchor> {
+        return AnchorPair(first: centerXAnchor, second: centerYAnchor)
     }
 
 }
 
-// MARK: - EdgeAnchors
+// MARK: - AnchorGroup
 
-public struct AxisAnchors<T: LayoutAxisType>: LayoutAnchorType {
-    private var top: T?
-    private var leading: T?
-    private var bottom: T?
-    private var trailing: T?
+public struct AnchorPair<T: LayoutAxisType, U: LayoutAxisType>: LayoutAnchorType {
+    private var first: T
+    private var second: U
 
-    init(top: T?, leading: T?, bottom: T?, trailing: T?) {
-        self.top = top
-        self.leading = leading
-        self.bottom = bottom
-        self.trailing = trailing
+    init(first: T, second: U) {
+        self.first = first
+        self.second = second
     }
 
-    public func activate(constraintsEqualTo anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
         let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsLessThanOrEqualTo anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
-        let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=)
+    public func activate(constraintsLessThanOrEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+        let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=, centerX: <=, centerY: <=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsGreaterThanOrEqualTo anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
-        let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=)
+    public func activate(constraintsGreaterThanOrEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+        let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=, centerX: >=, centerY: >=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    subscript (edge: LayoutEdge) -> LayoutAxisType? {
-        switch edge {
-        case .top:      return top
-        case .leading:  return leading
-        case .bottom:   return bottom
-        case .trailing: return trailing
-        }
-    }
-
-    func constraints(forAnchors anchors: AxisAnchors<T>?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> EdgeConstraints {
+    func constraints(forAnchors anchors: AnchorPair<T, U>?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> ConstraintGroup {
         guard let anchors = anchors else {
             preconditionFailure("Encountered nil edge anchors, indicating internal inconsistency of this API.")
         }
 
-        var edgeConstraints = EdgeConstraints()
-        let edges: [LayoutEdge] = [.top, .leading, .bottom, .trailing]
-        for edge in edges {
-            if let x = self[edge] as? NSLayoutXAxisAnchor, let otherX = anchors[edge] as? NSLayoutXAxisAnchor {
-                let expression = (otherX + edge.transform(constant: c)) ~ priority
-                edgeConstraints[edge] = builder.horizontalBuilder(forEdge: edge)(x, expression)
-            } else if let y = self[edge] as? NSLayoutYAxisAnchor, let otherY = anchors[edge] as? NSLayoutYAxisAnchor {
-                let expression = (otherY + edge.transform(constant: c)) ~ priority
-                edgeConstraints[edge] = builder.verticalBuilder(forEdge: edge)(y, expression)
-            } else if self[edge] != nil || anchors[edge] != nil {
-                preconditionFailure("Layout axes of constrained anchors must match.")
-            }
+        var constraintGroup = ConstraintGroup()
+
+        switch (first, anchors.first, second, anchors.second) {
+        // Leading, trailing
+        case let (firstX as NSLayoutXAxisAnchor, otherFirstX as NSLayoutXAxisAnchor,
+                  secondX as NSLayoutXAxisAnchor, otherSecondX as NSLayoutXAxisAnchor):
+            constraintGroup.leading = builder.leadingBuilder(firstX, (otherFirstX + c) ~ priority)
+            constraintGroup.trailing = builder.trailingBuilder(secondX, (otherSecondX - c) ~ priority)
+        //Top, bottom
+        case let (firstY as NSLayoutYAxisAnchor, otherFirstY as NSLayoutYAxisAnchor,
+                  secondY as NSLayoutYAxisAnchor, otherSecondY as NSLayoutYAxisAnchor):
+            constraintGroup.top = builder.topBuilder(firstY, (otherFirstY + c) ~ priority)
+            constraintGroup.bottom = builder.bottomBuilder(secondY, (otherSecondY - c) ~ priority)
+        //CenterX, centerY
+        case let (firstX as NSLayoutXAxisAnchor, otherFirstX as NSLayoutXAxisAnchor,
+                  firstY as NSLayoutYAxisAnchor, otherFirstY as NSLayoutYAxisAnchor):
+            constraintGroup.leading = builder.leadingBuilder(firstX, (otherFirstX + c) ~ priority)
+            constraintGroup.top = builder.topBuilder(firstY, (otherFirstY + c) ~ priority)
+        default:
+            preconditionFailure("Layout axes of constrained anchors must match.")
         }
-        return edgeConstraints
+
+        return constraintGroup
     }
 }
 
 public struct EdgeAnchors: LayoutAnchorType {
-    let horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor>
-    let verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor>
+    let horizontalAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor>
+    let verticalAnchors: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor>
 
-    init(horizontal: AxisAnchors<NSLayoutXAxisAnchor>, vertical: AxisAnchors<NSLayoutYAxisAnchor>) {
+    init(horizontal: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor>, vertical: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor>) {
         self.horizontalAnchors = horizontal
         self.verticalAnchors = vertical
     }
 
-    public func activate(constraintsEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
         let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsLessThanOrEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
-        let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=)
+    public func activate(constraintsLessThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+        let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=, centerX: <=, centerY: <=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsGreaterThanOrEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
-        let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=)
+    public func activate(constraintsGreaterThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+        let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=, centerX: >=, centerY: >=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    func constraints(forAnchors anchors: EdgeAnchors?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> EdgeConstraints {
+    func constraints(forAnchors anchors: EdgeAnchors?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> ConstraintGroup {
         guard let anchors = anchors else {
             preconditionFailure("Encountered nil edge anchors, indicating internal inconsistency of this API.")
         }
 
         let horizontalConstraints = horizontalAnchors.constraints(forAnchors: anchors.horizontalAnchors, constant: c, priority: priority, builder: builder)
         let verticalConstraints = verticalAnchors.constraints(forAnchors: anchors.verticalAnchors, constant: c, priority: priority, builder: builder)
-        return EdgeConstraints(top: verticalConstraints.top,
+        return ConstraintGroup(top: verticalConstraints.top,
                                leading: horizontalConstraints.leading,
                                bottom: verticalConstraints.bottom,
-                               trailing: verticalConstraints.trailing)
+                               trailing: verticalConstraints.trailing,
+                               centerX: horizontalConstraints.centerX,
+                               centerY: verticalConstraints.centerY)
     }
-    
+
 }
 
-// MARK: - EdgeConstraints
+// MARK: - ConstraintGroup
 
-public struct EdgeConstraints {
+public struct ConstraintGroup {
 
     public var top: NSLayoutConstraint?
     public var leading: NSLayoutConstraint?
     public var bottom: NSLayoutConstraint?
     public var trailing: NSLayoutConstraint?
+    public var centerX: NSLayoutConstraint?
+    public var centerY: NSLayoutConstraint?
 
     public var horizontal: [NSLayoutConstraint] {
-        return [leading, trailing].flatMap { $0 }
+        return [leading, trailing, centerX].flatMap { $0 }
     }
 
     public var vertical: [NSLayoutConstraint] {
-        return [top, bottom].flatMap { $0 }
+        return [top, bottom, centerY].flatMap { $0 }
     }
 
     public var all: [NSLayoutConstraint] {
-        return [top, leading, bottom, trailing].flatMap { $0 }
-    }
-
-    subscript (edge: LayoutEdge) -> NSLayoutConstraint? {
-        get {
-            switch edge {
-            case .top:      return top
-            case .leading:  return leading
-            case .bottom:   return bottom
-            case .trailing: return trailing
-            }
-        }
-
-        set {
-            switch edge {
-            case .top:      top = newValue
-            case .leading:  leading = newValue
-            case .bottom:   bottom = newValue
-            case .trailing: trailing = newValue
-            }
-        }
+        return [top, leading, bottom, trailing, centerX, centerY].flatMap { $0 }
     }
 
 }
@@ -545,49 +506,50 @@ struct ConstraintBuilder {
     typealias Horizontal = (NSLayoutXAxisAnchor, LayoutExpression<NSLayoutXAxisAnchor>) -> NSLayoutConstraint
     typealias Vertical = (NSLayoutYAxisAnchor, LayoutExpression<NSLayoutYAxisAnchor>) -> NSLayoutConstraint
 
-    var top: Vertical
-    var leading: Horizontal
-    var bottom: Vertical
-    var trailing: Horizontal
+    var topBuilder: Vertical
+    var leadingBuilder: Horizontal
+    var bottomBuilder: Vertical
+    var trailingBuilder: Horizontal
+    var centerYBuilder: Vertical
+    var centerXBuilder: Horizontal
 
     #if swift(>=3.0)
     init(horizontal: @escaping Horizontal, vertical: @escaping Vertical) {
-        top = vertical
-        leading = horizontal
-        bottom = vertical
-        trailing = horizontal
+        topBuilder = vertical
+        leadingBuilder = horizontal
+        bottomBuilder = vertical
+        trailingBuilder = horizontal
+        centerYBuilder = vertical
+        centerXBuilder = horizontal
     }
-    init(leading: @escaping Horizontal, top: @escaping Vertical, trailing: @escaping Horizontal, bottom: @escaping Vertical) {
-        self.leading = leading
-        self.top = top
-        self.trailing = trailing
-        self.bottom = bottom
+    init(leading: @escaping Horizontal, top: @escaping Vertical, trailing: @escaping Horizontal,
+         bottom: @escaping Vertical, centerX: @escaping Horizontal, centerY: @escaping Vertical) {
+        leadingBuilder = leading
+        topBuilder = top
+        trailingBuilder = trailing
+        bottomBuilder = bottom
+        centerYBuilder = centerY
+        centerXBuilder = centerX
     }
     #else
     init(horizontal: Horizontal, vertical: Vertical) {
-        top = vertical
-        leading = horizontal
-        bottom = vertical
-        trailing = horizontal
+        topBuilder = vertical
+        leadingBuilder = horizontal
+        bottomBuilder = vertical
+        trailingBuilder = horizontal
+        centerYBuilder = vertical
+        centerXBuilder = horizontal
     }
-    init(leading: Horizontal, top: Vertical, trailing: Horizontal, bottom: Vertical) {
-        self.leading = leading
-        self.top = top
-        self.trailing = trailing
-        self.bottom = bottom
+    init(leading: Horizontal, top: Vertical, trailing: Horizontal, bottom: Vertical, centerX: Horizontal, centerY: Vertical) {
+        leadingBuilder = leading
+        topBuilder = top
+        trailingBuilder = trailing
+        bottomBuilder = bottom
+        centerYBuilder = centerY
+        centerXBuilder = centerX
     }
     #endif
-
-    func horizontalBuilder(forEdge edge: LayoutEdge) -> Horizontal {
-        assert(edge.axis == .horizontal)
-        return (edge == .leading) ? leading : trailing
-    }
-
-    func verticalBuilder(forEdge edge: LayoutEdge) -> Vertical {
-        assert(edge.axis == .vertical)
-        return (edge == .top) ? top : bottom
-    }
-
+    
 }
 
 // MARK: - Constraint Activation
@@ -597,9 +559,9 @@ func activate(constraint theConstraint: NSLayoutConstraint, withPriority priorit
     if let first = theConstraint.firstItem as? UIView {
         first.translatesAutoresizingMaskIntoConstraints = false
     }
-
+    
     theConstraint.priority = priority
     theConstraint.isActive = true
-
+    
     return theConstraint
 }

--- a/Anchorage.swift
+++ b/Anchorage.swift
@@ -39,263 +39,263 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
 
 #if swift(>=3.0)
 
-    // MARK: - Equality Constraints
+// MARK: - Equality Constraints
 
-    @discardableResult public func == (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(equalToConstant: rhs))
+@discardableResult public func == (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(equalToConstant: rhs))
+}
+
+@discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(equalTo: rhs))
+}
+
+@discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(equalTo: rhs))
+}
+
+@discardableResult public func == (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(equalTo: rhs))
+}
+
+@discardableResult public func == <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func == <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func == <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func == (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
+    if let anchor = rhs.anchor {
+        return activate(constraint: lhs.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
-
-    @discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: NSLayoutXAxisAnchor) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(equalTo: rhs))
+    else {
+        return activate(constraint: lhs.constraint(equalToConstant: rhs.constant), withPriority: rhs.priority)
     }
+}
 
-    @discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: NSLayoutYAxisAnchor) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(equalTo: rhs))
+@discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    return lhs.activate(constraintsEqualToEdges: rhs)
+}
+
+@discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+    return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
+
+@discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+    return lhs.activate(constraintsEqualToEdges: rhs)
+}
+
+@discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+    return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
+
+// MARK: - Inequality Constraints
+
+@discardableResult public func <= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs))
+}
+
+@discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
+}
+
+@discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
+}
+
+@discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
+}
+
+@discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func <= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
+    if let anchor = rhs.anchor {
+        return activate(constraint: lhs.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
-
-    @discardableResult public func == (lhs: NSLayoutDimension, rhs: NSLayoutDimension) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(equalTo: rhs))
+    else {
+        return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
     }
+}
 
-    @discardableResult public func == <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+@discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+}
+
+@discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
+
+@discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+}
+
+@discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
+
+@discardableResult public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs))
+}
+
+@discardableResult public func >=<T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
+}
+
+@discardableResult public func >=<T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
+}
+
+@discardableResult public func >=<T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
+}
+
+@discardableResult public func >= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func >= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func >= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
+    return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+}
+
+@discardableResult public func >= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
+    if let anchor = rhs.anchor {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
     }
-
-    @discardableResult public func == <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    else {
+        return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
     }
+}
 
-    @discardableResult public func == <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-    }
+@discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+}
 
-    @discardableResult public func == (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
-        if let anchor = rhs.anchor {
-            return activate(constraint: lhs.constraint(equalTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
-        }
-        else {
-            return activate(constraint: lhs.constraint(equalToConstant: rhs.constant), withPriority: rhs.priority)
-        }
-    }
+@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
 
-    @discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
-        return lhs.activate(constraintsEqualToEdges: rhs)
-    }
+@discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+}
 
-    @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
-        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-    }
+@discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
 
-    @discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
-        return lhs.activate(constraintsEqualToEdges: rhs)
-    }
+// MARK: - Priority
 
-    @discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
-        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-    }
+precedencegroup PriorityPrecedence {
+    associativity: none
+    higherThan: ComparisonPrecedence
+}
 
-    // MARK: - Inequality Constraints
+infix operator ~: PriorityPrecedence
 
-    @discardableResult public func <= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs))
-    }
+@discardableResult public func ~ (lhs: CGFloat, rhs: UILayoutPriority) -> LayoutExpression<NSLayoutDimension> {
+    return LayoutExpression(constant: lhs, priority: rhs)
+}
 
-    @discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
-    }
+@discardableResult public func ~ <T: LayoutAnchorType>(lhs: T, rhs: UILayoutPriority) -> LayoutExpression<T> {
+    return LayoutExpression(anchor: lhs, priority: rhs)
+}
 
-    @discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
-    }
+@discardableResult public func ~ <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: UILayoutPriority) -> LayoutExpression<T> {
+    var expr = lhs
+    expr.priority = rhs
+    return expr
+}
 
-    @discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs))
-    }
+// MARK: Layout Expressions
 
-    @discardableResult public func <= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-    }
+@discardableResult public func * (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+    return LayoutExpression(anchor: lhs, multiplier: rhs)
+}
 
-    @discardableResult public func <= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-    }
+@discardableResult public func * (lhs: CGFloat, rhs: NSLayoutDimension) -> LayoutExpression<NSLayoutDimension> {
+    return LayoutExpression(anchor: rhs, multiplier: lhs)
+}
 
-    @discardableResult public func <= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-    }
+@discardableResult public func * (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+    var expr = lhs
+    expr.multiplier *= rhs
+    return expr
+}
 
-    @discardableResult public func <= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
-        if let anchor = rhs.anchor {
-            return activate(constraint: lhs.constraint(lessThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
-        }
-        else {
-            return activate(constraint: lhs.constraint(lessThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
-        }
-    }
+@discardableResult public func * (lhs: CGFloat, rhs: LayoutExpression<NSLayoutDimension>) -> LayoutExpression<NSLayoutDimension> {
+    var expr = rhs
+    expr.multiplier *= lhs
+    return expr
+}
 
-    @discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
-    }
+@discardableResult public func / (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+    return LayoutExpression(anchor: lhs, multiplier: 1.0 / rhs)
+}
 
-    @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-    }
+@discardableResult public func / (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
+    var expr = lhs
+    expr.multiplier /= rhs
+    return expr
+}
 
-    @discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
-    }
+@discardableResult public func + <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
+    return LayoutExpression(anchor: lhs, constant: rhs)
+}
 
-    @discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-    }
+@discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
+    return LayoutExpression(anchor: rhs, constant: lhs)
+}
 
-    @discardableResult public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs))
-    }
+@discardableResult public func + <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
+    var expr = lhs
+    expr.constant += rhs
+    return expr
+}
 
-    @discardableResult public func >=<T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
-    }
+@discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
+    var expr = rhs
+    expr.constant += lhs
+    return expr
+}
 
-    @discardableResult public func >=<T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
-    }
+@discardableResult public func - <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
+    return LayoutExpression(anchor: lhs, constant: -rhs)
+}
 
-    @discardableResult public func >=<T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
-    }
+@discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
+    return LayoutExpression(anchor: rhs, constant: -lhs)
+}
 
-    @discardableResult public func >= <T: NSLayoutDimension>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-    }
+@discardableResult public func - <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
+    var expr = lhs
+    expr.constant -= rhs
+    return expr
+}
 
-    @discardableResult public func >= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-    }
-
-    @discardableResult public func >= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: LayoutExpression<T>) -> NSLayoutConstraint {
-        return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
-    }
-
-    @discardableResult public func >= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension>) -> NSLayoutConstraint {
-        if let anchor = rhs.anchor {
-            return activate(constraint: lhs.constraint(greaterThanOrEqualTo: anchor, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
-        }
-        else {
-            return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs.constant), withPriority: rhs.priority)
-        }
-    }
-
-    @discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
-    }
-
-    @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-    }
-
-    @discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
-    }
-
-    @discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
-    }
-
-    // MARK: - Priority
-
-    precedencegroup PriorityPrecedence {
-        associativity: none
-        higherThan: ComparisonPrecedence
-    }
-
-    infix operator ~: PriorityPrecedence
-
-    @discardableResult public func ~ (lhs: CGFloat, rhs: UILayoutPriority) -> LayoutExpression<NSLayoutDimension> {
-        return LayoutExpression(constant: lhs, priority: rhs)
-    }
-
-    @discardableResult public func ~ <T: LayoutAnchorType>(lhs: T, rhs: UILayoutPriority) -> LayoutExpression<T> {
-        return LayoutExpression(anchor: lhs, priority: rhs)
-    }
-
-    @discardableResult public func ~ <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: UILayoutPriority) -> LayoutExpression<T> {
-        var expr = lhs
-        expr.priority = rhs
-        return expr
-    }
-
-    // MARK: Layout Expressions
-
-    @discardableResult public func * (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-        return LayoutExpression(anchor: lhs, multiplier: rhs)
-    }
-
-    @discardableResult public func * (lhs: CGFloat, rhs: NSLayoutDimension) -> LayoutExpression<NSLayoutDimension> {
-        return LayoutExpression(anchor: rhs, multiplier: lhs)
-    }
-
-    @discardableResult public func * (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-        var expr = lhs
-        expr.multiplier *= rhs
-        return expr
-    }
-
-    @discardableResult public func * (lhs: CGFloat, rhs: LayoutExpression<NSLayoutDimension>) -> LayoutExpression<NSLayoutDimension> {
-        var expr = rhs
-        expr.multiplier *= lhs
-        return expr
-    }
-
-    @discardableResult public func / (lhs: NSLayoutDimension, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-        return LayoutExpression(anchor: lhs, multiplier: 1.0 / rhs)
-    }
-
-    @discardableResult public func / (lhs: LayoutExpression<NSLayoutDimension>, rhs: CGFloat) -> LayoutExpression<NSLayoutDimension> {
-        var expr = lhs
-        expr.multiplier /= rhs
-        return expr
-    }
-
-    @discardableResult public func + <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
-        return LayoutExpression(anchor: lhs, constant: rhs)
-    }
-
-    @discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
-        return LayoutExpression(anchor: rhs, constant: lhs)
-    }
-
-    @discardableResult public func + <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
-        var expr = lhs
-        expr.constant += rhs
-        return expr
-    }
-
-    @discardableResult public func + <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
-        var expr = rhs
-        expr.constant += lhs
-        return expr
-    }
-
-    @discardableResult public func - <T: LayoutAnchorType>(lhs: T, rhs: CGFloat) -> LayoutExpression<T> {
-        return LayoutExpression(anchor: lhs, constant: -rhs)
-    }
-
-    @discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: T) -> LayoutExpression<T> {
-        return LayoutExpression(anchor: rhs, constant: -lhs)
-    }
-
-    @discardableResult public func - <T: LayoutAnchorType>(lhs: LayoutExpression<T>, rhs: CGFloat) -> LayoutExpression<T> {
-        var expr = lhs
-        expr.constant -= rhs
-        return expr
-    }
-
-    @discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
-        var expr = rhs
-        expr.constant -= lhs
-        return expr
-    }
+@discardableResult public func - <T: LayoutAnchorType>(lhs: CGFloat, rhs: LayoutExpression<T>) -> LayoutExpression<T> {
+    var expr = rhs
+    expr.constant -= lhs
+    return expr
+}
 
 #endif
 

--- a/Anchorage.swift
+++ b/Anchorage.swift
@@ -39,7 +39,7 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
 
 #if swift(>=3.0)
 
-// MARK: - Equality Constraints
+    // MARK: - Equality Constraints
 
 @discardableResult public func == (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
     return activate(constraint: lhs.constraint(equalToConstant: rhs))
@@ -78,19 +78,19 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
     }
 }
 
-@discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+@discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeGroup {
     return lhs.activate(constraintsEqualToEdges: rhs)
 }
 
-@discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+@discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeGroup {
     return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
-@discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+@discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> AxisGroup {
     return lhs.activate(constraintsEqualToEdges: rhs)
 }
 
-@discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+@discardableResult public func == <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> AxisGroup {
     return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
@@ -133,19 +133,19 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
     }
 }
 
-@discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+@discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeGroup {
     return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
 }
 
-@discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+@discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeGroup {
     return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
-@discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+@discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> AxisGroup {
     return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
 }
 
-@discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+@discardableResult public func <= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> AxisGroup {
     return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
@@ -186,19 +186,19 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
     }
 }
 
-@discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+@discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeGroup {
     return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
 }
 
-@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+@discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeGroup {
     return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
-@discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+@discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> AxisGroup {
     return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
 }
 
-@discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+@discardableResult public func >= <T: LayoutAxisType, U: LayoutAxisType>(lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> AxisGroup {
     return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
@@ -387,115 +387,114 @@ public struct AnchorPair<T: LayoutAxisType, U: LayoutAxisType>: LayoutAnchorType
         self.second = second
     }
 
-    public func activate(constraintsEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+    public func activate(constraintsEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> AxisGroup {
         let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsLessThanOrEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+    public func activate(constraintsLessThanOrEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> AxisGroup {
         let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=, centerX: <=, centerY: <=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsGreaterThanOrEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+    public func activate(constraintsGreaterThanOrEqualToEdges anchor: AnchorPair<T, U>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> AxisGroup {
         let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=, centerX: >=, centerY: >=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    func constraints(forAnchors anchors: AnchorPair<T, U>?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> ConstraintGroup {
+    func constraints(forAnchors anchors: AnchorPair<T, U>?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> AxisGroup {
         guard let anchors = anchors else {
             preconditionFailure("Encountered nil edge anchors, indicating internal inconsistency of this API.")
         }
 
-        var constraintGroup = ConstraintGroup()
-
         switch (first, anchors.first, second, anchors.second) {
-        // Leading, trailing
+            // Leading, trailing
         case let (firstX as NSLayoutXAxisAnchor, otherFirstX as NSLayoutXAxisAnchor,
                   secondX as NSLayoutXAxisAnchor, otherSecondX as NSLayoutXAxisAnchor):
-            constraintGroup.leading = builder.leadingBuilder(firstX, (otherFirstX + c) ~ priority)
-            constraintGroup.trailing = builder.trailingBuilder(secondX, (otherSecondX - c) ~ priority)
-        //Top, bottom
+            return AxisGroup(first: builder.leadingBuilder(firstX, (otherFirstX + c) ~ priority),
+                             second: builder.trailingBuilder(secondX, (otherSecondX - c) ~ priority))
+            //Top, bottom
         case let (firstY as NSLayoutYAxisAnchor, otherFirstY as NSLayoutYAxisAnchor,
                   secondY as NSLayoutYAxisAnchor, otherSecondY as NSLayoutYAxisAnchor):
-            constraintGroup.top = builder.topBuilder(firstY, (otherFirstY + c) ~ priority)
-            constraintGroup.bottom = builder.bottomBuilder(secondY, (otherSecondY - c) ~ priority)
-        //CenterX, centerY
+            return AxisGroup(first: builder.topBuilder(firstY, (otherFirstY + c) ~ priority),
+                             second: builder.bottomBuilder(secondY, (otherSecondY - c) ~ priority))
+            //CenterX, centerY
         case let (firstX as NSLayoutXAxisAnchor, otherFirstX as NSLayoutXAxisAnchor,
                   firstY as NSLayoutYAxisAnchor, otherFirstY as NSLayoutYAxisAnchor):
-            constraintGroup.leading = builder.leadingBuilder(firstX, (otherFirstX + c) ~ priority)
-            constraintGroup.top = builder.topBuilder(firstY, (otherFirstY + c) ~ priority)
+            return AxisGroup(first: builder.leadingBuilder(firstX, (otherFirstX + c) ~ priority),
+                             second: builder.topBuilder(firstY, (otherFirstY - c) ~ priority))
         default:
             preconditionFailure("Layout axes of constrained anchors must match.")
         }
-
-        return constraintGroup
     }
 }
 
 public struct EdgeAnchors: LayoutAnchorType {
-    let horizontalAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor>
-    let verticalAnchors: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor>
+    var horizontalAnchors: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor>
+    var verticalAnchors: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor>
 
     init(horizontal: AnchorPair<NSLayoutXAxisAnchor, NSLayoutXAxisAnchor>, vertical: AnchorPair<NSLayoutYAxisAnchor, NSLayoutYAxisAnchor>) {
         self.horizontalAnchors = horizontal
         self.verticalAnchors = vertical
     }
 
-    public func activate(constraintsEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+    public func activate(constraintsEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeGroup {
         let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsLessThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+    public func activate(constraintsLessThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeGroup {
         let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=, centerX: <=, centerY: <=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsGreaterThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> ConstraintGroup {
+    public func activate(constraintsGreaterThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeGroup {
         let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=, centerX: >=, centerY: >=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    func constraints(forAnchors anchors: EdgeAnchors?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> ConstraintGroup {
+    func constraints(forAnchors anchors: EdgeAnchors?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> EdgeGroup {
         guard let anchors = anchors else {
             preconditionFailure("Encountered nil edge anchors, indicating internal inconsistency of this API.")
         }
 
         let horizontalConstraints = horizontalAnchors.constraints(forAnchors: anchors.horizontalAnchors, constant: c, priority: priority, builder: builder)
         let verticalConstraints = verticalAnchors.constraints(forAnchors: anchors.verticalAnchors, constant: c, priority: priority, builder: builder)
-        return ConstraintGroup(top: verticalConstraints.top,
-                               leading: horizontalConstraints.leading,
-                               bottom: verticalConstraints.bottom,
-                               trailing: verticalConstraints.trailing,
-                               centerX: horizontalConstraints.centerX,
-                               centerY: verticalConstraints.centerY)
+        return EdgeGroup(top: verticalConstraints.first,
+                         leading: horizontalConstraints.first,
+                         bottom: verticalConstraints.second,
+                         trailing: verticalConstraints.second)
     }
 
 }
 
 // MARK: - ConstraintGroup
 
-public struct ConstraintGroup {
+public struct EdgeGroup {
 
-    public var top: NSLayoutConstraint?
-    public var leading: NSLayoutConstraint?
-    public var bottom: NSLayoutConstraint?
-    public var trailing: NSLayoutConstraint?
-    public var centerX: NSLayoutConstraint?
-    public var centerY: NSLayoutConstraint?
+    public var top: NSLayoutConstraint
+    public var leading: NSLayoutConstraint
+    public var bottom: NSLayoutConstraint
+    public var trailing: NSLayoutConstraint
 
     public var horizontal: [NSLayoutConstraint] {
-        return [leading, trailing, centerX].flatMap { $0 }
+        return [leading, trailing].flatMap { $0 }
     }
 
     public var vertical: [NSLayoutConstraint] {
-        return [top, bottom, centerY].flatMap { $0 }
+        return [top, bottom].flatMap { $0 }
     }
 
     public var all: [NSLayoutConstraint] {
-        return [top, leading, bottom, trailing, centerX, centerY].flatMap { $0 }
+        return [top, leading, bottom, trailing].flatMap { $0 }
     }
+
+}
+
+public struct AxisGroup {
+
+    public var first: NSLayoutConstraint
+    public var second: NSLayoutConstraint
 
 }
 
@@ -549,7 +548,7 @@ struct ConstraintBuilder {
         centerXBuilder = centerX
     }
     #endif
-    
+
 }
 
 // MARK: - Constraint Activation
@@ -559,9 +558,9 @@ func activate(constraint theConstraint: NSLayoutConstraint, withPriority priorit
     if let first = theConstraint.firstItem as? UIView {
         first.translatesAutoresizingMaskIntoConstraints = false
     }
-    
+
     theConstraint.priority = priority
     theConstraint.isActive = true
-    
+
     return theConstraint
 }

--- a/Anchorage.swift
+++ b/Anchorage.swift
@@ -33,6 +33,10 @@ extension NSLayoutDimension : LayoutAnchorType {}
 extension NSLayoutXAxisAnchor : LayoutAnchorType {}
 extension NSLayoutYAxisAnchor : LayoutAnchorType {}
 
+public protocol LayoutAxisType {}
+extension NSLayoutXAxisAnchor : LayoutAxisType {}
+extension NSLayoutYAxisAnchor : LayoutAxisType {}
+
 #if swift(>=3.0)
 
     // MARK: - Equality Constraints
@@ -75,11 +79,11 @@ extension NSLayoutYAxisAnchor : LayoutAnchorType {}
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activeConstraints(equalTo: rhs)
+    return lhs.activate(constraintsEqualToEdges: rhs)
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activeConstraints(equalTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 // MARK: - Inequality Constraints
@@ -122,11 +126,11 @@ extension NSLayoutYAxisAnchor : LayoutAnchorType {}
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activeConstraints(lessThanOrEqualTo: rhs)
+    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activeConstraints(lessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
@@ -167,11 +171,11 @@ extension NSLayoutYAxisAnchor : LayoutAnchorType {}
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activeConstraints(greaterThanOrEqualTo: rhs)
+    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activeConstraints(greaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 // MARK: - Priority
@@ -289,46 +293,53 @@ public struct LayoutExpression<T : LayoutAnchorType> {
 
 // MARK: - EdgeAnchorsProvider
 
-public protocol EdgeAnchorsProvider {
+public protocol AnchorGroupProvider {
 
-    var edgeAnchors: EdgeAnchors { get }
-
-}
-
-extension EdgeAnchorsProvider {
-
-    public var horizontalAnchors: EdgeAnchors {
-        return edgeAnchors.filter(onlyEdges: LayoutEdge.Horizontal)
-    }
-
-    public var verticalAnchors: EdgeAnchors {
-        return edgeAnchors.filter(onlyEdges: LayoutEdge.Vertical)
-    }
+    var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> { get }
+    var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> { get }
 
 }
 
-extension UIView: EdgeAnchorsProvider {
+extension AnchorGroupProvider {
 
     public var edgeAnchors: EdgeAnchors {
-        return EdgeAnchors(top: topAnchor, leading: leadingAnchor, bottom: bottomAnchor, trailing: trailingAnchor)
+        return EdgeAnchors(horizontal: horizontalAnchors, vertical: verticalAnchors)
     }
 
 }
 
-extension UIViewController: EdgeAnchorsProvider {
 
-    public var edgeAnchors: EdgeAnchors {
-        return EdgeAnchors(top: topLayoutGuide.bottomAnchor, leading: view.leadingAnchor, bottom: bottomLayoutGuide.topAnchor, trailing: view.trailingAnchor)
+extension UIView: AnchorGroupProvider {
+
+    public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
+        return AxisAnchors(leading: leadingAnchor, trailing: trailingAnchor)
+    }
+    public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
+        return AxisAnchors(leading: topAnchor, trailing: bottomAnchor)
     }
 
 }
 
-extension UILayoutGuide: EdgeAnchorsProvider {
+extension UIViewController: AnchorGroupProvider {
 
-    public var edgeAnchors: EdgeAnchors {
-        return EdgeAnchors(top: topAnchor, leading: leadingAnchor, bottom: bottomAnchor, trailing: trailingAnchor)
+    public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
+        return AxisAnchors(leading: view.leadingAnchor, trailing: view.trailingAnchor)
+    }
+    public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
+        return AxisAnchors(leading: topLayoutGuide.bottomAnchor, trailing: bottomLayoutGuide.topAnchor)
     }
 
+}
+
+extension UILayoutGuide: AnchorGroupProvider {
+
+    public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
+        return AxisAnchors(leading: leadingAnchor, trailing: trailingAnchor)
+    }
+    public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
+        return AxisAnchors(leading: topAnchor, trailing: bottomAnchor)
+    }
+    
 }
 
 // MARK: - LayoutEdge
@@ -339,15 +350,6 @@ enum LayoutEdge {
     static let Horizontal = [leading, trailing]
     static let Vertical = [top, bottom]
     static let All = [top, leading, bottom, trailing]
-
-    var axis: UILayoutConstraintAxis {
-        switch self {
-        case .top, .bottom:
-            return .vertical
-        case.leading, .trailing:
-            return .horizontal
-        }
-    }
 
     func transform(constant theConstant: CGFloat) -> CGFloat {
         switch self {
@@ -362,98 +364,97 @@ enum LayoutEdge {
 
 // MARK: - EdgeAnchors
 
-public struct EdgeAnchors: LayoutAnchorType {
-    
-    private var top: NSLayoutYAxisAnchor
-    private var leading: NSLayoutXAxisAnchor
-    private var bottom: NSLayoutYAxisAnchor
-    private var trailing: NSLayoutXAxisAnchor
+public struct AxisAnchors<T: LayoutAxisType>: LayoutAnchorType {
+    private var leading: T
+    private var trailing: T
 
-    private var includedEdges = LayoutEdge.All
-
-    init(top: NSLayoutYAxisAnchor, leading: NSLayoutXAxisAnchor, bottom: NSLayoutYAxisAnchor, trailing: NSLayoutXAxisAnchor) {
-        self.top = top
+    init(leading: T, trailing: T) {
         self.leading = leading
-        self.bottom = bottom
         self.trailing = trailing
     }
 
-    func filter(onlyEdges edges: [LayoutEdge]) -> EdgeAnchors {
-        var filteredAnchors = self
-        filteredAnchors.includedEdges = includedEdges.filter { edges.contains($0) }
-
-        return filteredAnchors
+    public func activate(constraintsEqualToEdges anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+        let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
+        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activeConstraints(equalTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
-        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: ConstraintBuilder(horizontal: ==, vertical: ==))
+    public func activate(constraintsLessThanOrEqualToEdges anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+        let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=)
+        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activeConstraints(lessThanOrEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
-        var constraintBuilder = ConstraintBuilder(horizontal: <=, vertical: <=)
-
-        if includedEdges.contains(.leading) && includedEdges.index(of: .trailing) == anchor?.includedEdges.index(of: .trailing) {
-            constraintBuilder.trailing = (>=)
-        }
-
-        if includedEdges.contains(.top) && includedEdges.index(of: .bottom) == anchor?.includedEdges.index(of: .bottom) {
-            constraintBuilder.bottom = (>=)
-        }
-
-        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: constraintBuilder)
+    public func activate(constraintsGreaterThanOrEqualToEdges anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+        let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=)
+        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activeConstraints(greaterThanOrEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
-        var constraintBuilder = ConstraintBuilder(horizontal: >=, vertical: >=)
-
-        if includedEdges.contains(.leading) && includedEdges.index(of: .trailing) == anchor?.includedEdges.index(of: .trailing) {
-            constraintBuilder.trailing = (<=)
-        }
-
-        if includedEdges.contains(.top) && includedEdges.index(of: .bottom) == anchor?.includedEdges.index(of: .bottom) {
-            constraintBuilder.bottom = (<=)
-        }
-
-        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: constraintBuilder)
-    }
-
-    subscript (edge: LayoutEdge) -> LayoutAnchorType {
+    subscript (edge: LayoutEdge) -> LayoutAxisType? {
         switch edge {
-        case .top:      return top
         case .leading:  return leading
-        case .bottom:   return bottom
         case .trailing: return trailing
+        default: return nil
         }
     }
 
-    private func constraints(forAnchors anchors: EdgeAnchors?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> EdgeConstraints {
+    func constraints(forAnchors anchors: AxisAnchors<T>?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> EdgeConstraints {
         guard let anchors = anchors else {
             preconditionFailure("Encountered nil edge anchors, indicating internal inconsistency of this API.")
         }
 
         var edgeConstraints = EdgeConstraints()
-
-        zip(includedEdges, anchors.includedEdges).forEach { (edge, otherEdge) in
-            edgeConstraints[edge] = {
-                switch (self[edge], anchors[otherEdge]) {
-
-                case let (x as NSLayoutXAxisAnchor, otherX as NSLayoutXAxisAnchor):
-                    let expression = (otherX + edge.transform(constant: c)) ~ priority
-                    return builder.horizontalBuilder(forEdge: edge)(x, expression)
-
-                case let (y as NSLayoutYAxisAnchor, otherY as NSLayoutYAxisAnchor):
-                    let expression = (otherY + edge.transform(constant: c)) ~ priority
-                    return builder.verticalBuilder(forEdge: edge)(y, expression)
-
-                default:
-                    preconditionFailure("Layout axis of constrained anchors must match.")
-                }
-            }()
+        let edges: [LayoutEdge] = [.leading, .trailing]
+        for edge in edges {
+            if let x = self[edge] as? NSLayoutXAxisAnchor, let otherX = anchors[edge] as? NSLayoutXAxisAnchor {
+                let expression = (otherX + edge.transform(constant: c)) ~ priority
+                edgeConstraints[edge] = builder.horizontalBuilder(forEdge: edge)(x, expression)
+            } else if let y = self[edge] as? NSLayoutYAxisAnchor, let otherY = anchors[edge] as? NSLayoutYAxisAnchor {
+                let expression = (otherY + edge.transform(constant: c)) ~ priority
+                edgeConstraints[edge] = builder.verticalBuilder(forEdge: edge)(y, expression)
+            } else if self[edge] != nil || anchors[edge] != nil {
+                preconditionFailure("Layout axes of constrained anchors must match.")
+            }
         }
-
         return edgeConstraints
     }
+}
 
+public struct EdgeAnchors: LayoutAnchorType {
+    let horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor>
+    let verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor>
+
+    init(horizontal: AxisAnchors<NSLayoutXAxisAnchor>, vertical: AxisAnchors<NSLayoutYAxisAnchor>) {
+        self.horizontalAnchors = horizontal
+        self.verticalAnchors = vertical
+    }
+
+    public func activate(constraintsEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+        let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
+        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
+    }
+
+    public func activate(constraintsLessThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+        let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=)
+        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
+    }
+
+    public func activate(constraintsGreaterThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+        let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=)
+        return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
+    }
+
+    func constraints(forAnchors anchors: EdgeAnchors?, constant c: CGFloat, priority: UILayoutPriority, builder: ConstraintBuilder) -> EdgeConstraints {
+        guard let anchors = anchors else {
+            preconditionFailure("Encountered nil edge anchors, indicating internal inconsistency of this API.")
+        }
+
+        let horizontalConstraints = horizontalAnchors.constraints(forAnchors: anchors.horizontalAnchors, constant: c, priority: priority, builder: builder)
+        let verticalConstraints = verticalAnchors.constraints(forAnchors: anchors.verticalAnchors, constant: c, priority: priority, builder: builder)
+        return EdgeConstraints(top: verticalConstraints.top,
+                               leading: horizontalConstraints.leading,
+                               bottom: verticalConstraints.bottom,
+                               trailing: verticalConstraints.trailing)
+    }
+    
 }
 
 // MARK: - EdgeConstraints
@@ -501,7 +502,7 @@ public struct EdgeConstraints {
 
 // MARK: - Constraint Builders
 
-private struct ConstraintBuilder {
+struct ConstraintBuilder {
 
     typealias Horizontal = (NSLayoutXAxisAnchor, LayoutExpression<NSLayoutXAxisAnchor>) -> NSLayoutConstraint
     typealias Vertical = (NSLayoutYAxisAnchor, LayoutExpression<NSLayoutYAxisAnchor>) -> NSLayoutConstraint
@@ -513,10 +514,16 @@ private struct ConstraintBuilder {
 
     #if swift(>=3.0)
     init(horizontal: @escaping Horizontal, vertical: @escaping Vertical) {
-        top = vertical
-        leading = horizontal
-        bottom = vertical
-        trailing = horizontal
+    top = vertical
+    leading = horizontal
+    bottom = vertical
+    trailing = horizontal
+    }
+    init(leading: @escaping Horizontal, top: @escaping Vertical, trailing: @escaping Horizontal, bottom: @escaping Vertical) {
+    self.leading = leading
+    self.top = top
+    self.trailing = trailing
+    self.bottom = bottom
     }
     #else
     init(horizontal: Horizontal, vertical: Vertical) {
@@ -525,16 +532,19 @@ private struct ConstraintBuilder {
         bottom = vertical
         trailing = horizontal
     }
+    init(leading: Horizontal, top: Vertical, trailing: Horizontal, bottom: Vertical) {
+        self.leading = leading
+        self.top = top
+        self.trailing = trailing
+        self.bottom = bottom
+    }
     #endif
 
-
     func horizontalBuilder(forEdge edge: LayoutEdge) -> Horizontal {
-        assert(edge.axis == .horizontal)
         return (edge == .leading) ? leading : trailing
     }
 
     func verticalBuilder(forEdge edge: LayoutEdge) -> Vertical {
-        assert(edge.axis == .vertical)
         return (edge == .top) ? top : bottom
     }
 

--- a/Anchorage.swift
+++ b/Anchorage.swift
@@ -79,11 +79,19 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activate(constraintsEqualToEdges: rhs)
+    return lhs.activate(constraintsEqualTo: rhs)
 }
 
 @discardableResult public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
+
+@discardableResult public func == <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
+    return lhs.activate(constraintsEqualTo: rhs)
+}
+
+@discardableResult public func == <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
+    return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 // MARK: - Inequality Constraints
@@ -126,11 +134,19 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+    return lhs.activate(constraintsLessThanOrEqualTo: rhs)
 }
 
 @discardableResult public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
+
+@discardableResult public func <= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
+    return lhs.activate(constraintsLessThanOrEqualTo: rhs)
+}
+
+@discardableResult public func <= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
+    return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
@@ -171,11 +187,19 @@ extension NSLayoutYAxisAnchor : LayoutAxisType {}
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
 }
 
 @discardableResult public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-    return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+}
+
+@discardableResult public func >= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
+    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
+}
+
+@discardableResult public func >= <T: LayoutAxisType>(lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
+    return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
 }
 
 // MARK: - Priority
@@ -312,10 +336,10 @@ extension AnchorGroupProvider {
 extension UIView: AnchorGroupProvider {
 
     public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
-        return AxisAnchors(leading: leadingAnchor, trailing: trailingAnchor)
+        return AxisAnchors(top: nil, leading: leadingAnchor, bottom: nil, trailing: trailingAnchor)
     }
     public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
-        return AxisAnchors(leading: topAnchor, trailing: bottomAnchor)
+        return AxisAnchors(top: topAnchor, leading: nil, bottom: bottomAnchor, trailing: nil)
     }
 
 }
@@ -323,10 +347,10 @@ extension UIView: AnchorGroupProvider {
 extension UIViewController: AnchorGroupProvider {
 
     public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
-        return AxisAnchors(leading: view.leadingAnchor, trailing: view.trailingAnchor)
+        return AxisAnchors(top: nil, leading: view.leadingAnchor, bottom: nil, trailing: view.trailingAnchor)
     }
     public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
-        return AxisAnchors(leading: topLayoutGuide.bottomAnchor, trailing: bottomLayoutGuide.topAnchor)
+        return AxisAnchors(top: topLayoutGuide.bottomAnchor, leading: nil, bottom: bottomLayoutGuide.topAnchor, trailing: nil)
     }
 
 }
@@ -334,10 +358,10 @@ extension UIViewController: AnchorGroupProvider {
 extension UILayoutGuide: AnchorGroupProvider {
 
     public var horizontalAnchors: AxisAnchors<NSLayoutXAxisAnchor> {
-        return AxisAnchors(leading: leadingAnchor, trailing: trailingAnchor)
+        return AxisAnchors(top: nil, leading: leadingAnchor, bottom: nil, trailing: trailingAnchor)
     }
     public var verticalAnchors: AxisAnchors<NSLayoutYAxisAnchor> {
-        return AxisAnchors(leading: topAnchor, trailing: bottomAnchor)
+        return AxisAnchors(top: topAnchor, leading: nil, bottom: bottomAnchor, trailing: nil)
     }
     
 }
@@ -350,6 +374,15 @@ enum LayoutEdge {
     static let Horizontal = [leading, trailing]
     static let Vertical = [top, bottom]
     static let All = [top, leading, bottom, trailing]
+
+    var axis: UILayoutConstraintAxis {
+        switch self {
+        case .top, .bottom:
+            return .vertical
+        case .leading, .trailing:
+            return .horizontal
+        }
+    }
 
     func transform(constant theConstant: CGFloat) -> CGFloat {
         switch self {
@@ -365,34 +398,39 @@ enum LayoutEdge {
 // MARK: - EdgeAnchors
 
 public struct AxisAnchors<T: LayoutAxisType>: LayoutAnchorType {
-    private var leading: T
-    private var trailing: T
+    private var top: T?
+    private var leading: T?
+    private var bottom: T?
+    private var trailing: T?
 
-    init(leading: T, trailing: T) {
+    init(top: T?, leading: T?, bottom: T?, trailing: T?) {
+        self.top = top
         self.leading = leading
+        self.bottom = bottom
         self.trailing = trailing
     }
 
-    public func activate(constraintsEqualToEdges anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsEqualTo anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
         let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsLessThanOrEqualToEdges anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsLessThanOrEqualTo anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
         let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsGreaterThanOrEqualToEdges anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsGreaterThanOrEqualTo anchor: AxisAnchors<T>?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
         let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
     subscript (edge: LayoutEdge) -> LayoutAxisType? {
         switch edge {
+        case .top:      return top
         case .leading:  return leading
+        case .bottom:   return bottom
         case .trailing: return trailing
-        default: return nil
         }
     }
 
@@ -402,7 +440,7 @@ public struct AxisAnchors<T: LayoutAxisType>: LayoutAnchorType {
         }
 
         var edgeConstraints = EdgeConstraints()
-        let edges: [LayoutEdge] = [.leading, .trailing]
+        let edges: [LayoutEdge] = [.top, .leading, .bottom, .trailing]
         for edge in edges {
             if let x = self[edge] as? NSLayoutXAxisAnchor, let otherX = anchors[edge] as? NSLayoutXAxisAnchor {
                 let expression = (otherX + edge.transform(constant: c)) ~ priority
@@ -427,17 +465,17 @@ public struct EdgeAnchors: LayoutAnchorType {
         self.verticalAnchors = vertical
     }
 
-    public func activate(constraintsEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
         let builder = ConstraintBuilder(horizontal: ==, vertical: ==)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsLessThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsLessThanOrEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
         let builder = ConstraintBuilder(leading: <=, top: <=, trailing: >=, bottom: >=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
 
-    public func activate(constraintsGreaterThanOrEqualToEdges anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
+    public func activate(constraintsGreaterThanOrEqualTo anchor: EdgeAnchors?, constant c: CGFloat = 0.0, priority: UILayoutPriority = UILayoutPriorityRequired) -> EdgeConstraints {
         let builder = ConstraintBuilder(leading: >=, top: >=, trailing: <=, bottom: <=)
         return constraints(forAnchors: anchor, constant: c, priority: priority, builder: builder)
     }
@@ -514,16 +552,16 @@ struct ConstraintBuilder {
 
     #if swift(>=3.0)
     init(horizontal: @escaping Horizontal, vertical: @escaping Vertical) {
-    top = vertical
-    leading = horizontal
-    bottom = vertical
-    trailing = horizontal
+        top = vertical
+        leading = horizontal
+        bottom = vertical
+        trailing = horizontal
     }
     init(leading: @escaping Horizontal, top: @escaping Vertical, trailing: @escaping Horizontal, bottom: @escaping Vertical) {
-    self.leading = leading
-    self.top = top
-    self.trailing = trailing
-    self.bottom = bottom
+        self.leading = leading
+        self.top = top
+        self.trailing = trailing
+        self.bottom = bottom
     }
     #else
     init(horizontal: Horizontal, vertical: Vertical) {
@@ -541,10 +579,12 @@ struct ConstraintBuilder {
     #endif
 
     func horizontalBuilder(forEdge edge: LayoutEdge) -> Horizontal {
+        assert(edge.axis == .horizontal)
         return (edge == .leading) ? leading : trailing
     }
 
     func verticalBuilder(forEdge edge: LayoutEdge) -> Vertical {
+        assert(edge.axis == .vertical)
         return (edge == .top) ? top : bottom
     }
 

--- a/AnchorageCompatibility.swift
+++ b/AnchorageCompatibility.swift
@@ -70,20 +70,20 @@ import UIKit
         }
     }
 
-    public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualTo: rhs)
+    public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs)
     }
 
-    public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
-    public func == <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualTo: rhs)
+    public func == <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs)
     }
 
-    public func == <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    public func == <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     // MARK: - Compatability Inequality Constraints
@@ -125,20 +125,20 @@ import UIKit
         }
     }
 
-    public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualTo: rhs)
+    public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
     }
 
-    public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
-    public func <= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualTo: rhs)
+    public func <= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
     }
 
-    public func <= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    public func <= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
@@ -178,20 +178,20 @@ import UIKit
         }
     }
 
-    public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
+    public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
     }
 
-    public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
-    public func >= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
+    public func >= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
     }
 
-    public func >= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    public func >= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     // MARK: Compatability Priority

--- a/AnchorageCompatibility.swift
+++ b/AnchorageCompatibility.swift
@@ -71,11 +71,19 @@ import UIKit
     }
 
     public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activeConstraints(equalTo: rhs)
+        return lhs.activate(constraintsEqualToEdges: rhs)
     }
 
     public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activeConstraints(equalTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    public func == <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
+        return lhs.activate(constraintsEqualToEdges: rhs)
+    }
+
+    public func == <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
+        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     // MARK: - Compatability Inequality Constraints
@@ -118,11 +126,19 @@ import UIKit
     }
 
     public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activeConstraints(lessThanOrEqualTo: rhs)
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
     }
 
     public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activeConstraints(lessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    public func <= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+    }
+
+    public func <= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
+        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
@@ -163,11 +179,19 @@ import UIKit
     }
 
     public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activeConstraints(greaterThanOrEqualTo: rhs)
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
     }
 
     public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activeConstraints(greaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+    }
+
+    public func >= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+    }
+
+    public func >= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
+        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     // MARK: Compatability Priority

--- a/AnchorageCompatibility.swift
+++ b/AnchorageCompatibility.swift
@@ -71,19 +71,19 @@ import UIKit
     }
 
     public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualToEdges: rhs)
+        return lhs.activate(constraintsEqualTo: rhs)
     }
 
     public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     public func == <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualToEdges: rhs)
+        return lhs.activate(constraintsEqualTo: rhs)
     }
 
     public func == <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-        return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     // MARK: - Compatability Inequality Constraints
@@ -126,19 +126,19 @@ import UIKit
     }
 
     public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+        return lhs.activate(constraintsLessThanOrEqualTo: rhs)
     }
 
     public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     public func <= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
+        return lhs.activate(constraintsLessThanOrEqualTo: rhs)
     }
 
     public func <= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-        return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsLessThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     public func >= (lhs: NSLayoutDimension, rhs: CGFloat) -> NSLayoutConstraint {
@@ -179,19 +179,19 @@ import UIKit
     }
 
     public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
     }
 
     public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     public func >= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: AxisAnchors<T>) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
+        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs)
     }
 
     public func >= <T: LayoutAxisType> (lhs: AxisAnchors<T>, rhs: LayoutExpression<AxisAnchors<T>>) -> EdgeConstraints {
-        return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
+        return lhs.activate(constraintsGreaterThanOrEqualTo: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
     // MARK: Compatability Priority

--- a/AnchorageCompatibility.swift
+++ b/AnchorageCompatibility.swift
@@ -70,19 +70,19 @@ import UIKit
         }
     }
 
-    public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    public func == (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeGroup {
         return lhs.activate(constraintsEqualToEdges: rhs)
     }
 
-    public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+    public func == (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeGroup {
         return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
-    public func == <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+    public func == <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> AxisGroup {
         return lhs.activate(constraintsEqualToEdges: rhs)
     }
 
-    public func == <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+    public func == <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> AxisGroup {
         return lhs.activate(constraintsEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
@@ -125,19 +125,19 @@ import UIKit
         }
     }
 
-    public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    public func <= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeGroup {
         return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
     }
 
-    public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+    public func <= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeGroup {
         return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
-    public func <= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+    public func <= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> AxisGroup {
         return lhs.activate(constraintsLessThanOrEqualToEdges: rhs)
     }
 
-    public func <= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+    public func <= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> AxisGroup {
         return lhs.activate(constraintsLessThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
@@ -145,15 +145,15 @@ import UIKit
         return activate(constraint: lhs.constraint(greaterThanOrEqualToConstant: rhs))
     }
 
-    public func >=<T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    public func >= <T: NSLayoutDimension>(lhs: T, rhs: T) -> NSLayoutConstraint {
         return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
     }
 
-    public func >=<T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    public func >= <T: NSLayoutXAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
         return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
     }
 
-    public func >=<T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
+    public func >= <T: NSLayoutYAxisAnchor>(lhs: T, rhs: T) -> NSLayoutConstraint {
         return activate(constraint: lhs.constraint(greaterThanOrEqualTo: rhs))
     }
 
@@ -178,19 +178,19 @@ import UIKit
         }
     }
 
-    public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> ConstraintGroup {
+    public func >= (lhs: EdgeAnchors, rhs: EdgeAnchors) -> EdgeGroup {
         return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
     }
 
-    public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> ConstraintGroup {
+    public func >= (lhs: EdgeAnchors, rhs: LayoutExpression<EdgeAnchors>) -> EdgeGroup {
         return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 
-    public func >= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> ConstraintGroup {
+    public func >= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: AnchorPair<T, U>) -> AxisGroup {
         return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs)
     }
 
-    public func >= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> ConstraintGroup {
+    public func >= <T: LayoutAxisType, U: LayoutAxisType> (lhs: AnchorPair<T, U>, rhs: LayoutExpression<AnchorPair<T, U>>) -> AxisGroup {
         return lhs.activate(constraintsGreaterThanOrEqualToEdges: rhs.anchor, constant: rhs.constant, priority: rhs.priority)
     }
 


### PR DESCRIPTION
Fixes #8 and #13:
- Creates `AnchorPair` struct that creates constraints along 2 edges (or both centers)
- Removes need for `LayoutEdge` enum (downside to this: "transforming" constraints is handled case-by-case)
- `EdgeAnchors` composes from `horizontalAnchors` and `verticalAnchors`
- `ConstraintBuilder` and `EdgeConstraints` (renamed to `ConstraintGroup`) add support for center anchors

