### PR TITLE
On CircleCI, use `--verbose` flag for Carthage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ test:
     - ./scripts/tvOS_Swift_3.sh
     - ./scripts/tvOS_Swift_4.sh
   post:
-    - carthage build --no-skip-current && for platform in Mac iOS tvOS; do test -d Carthage/Build/${platform}/Anchorage.framework || exit 1; done
+    - carthage build --verbose --no-skip-current && for platform in Mac iOS tvOS; do test -d Carthage/Build/${platform}/Anchorage.framework || exit 1; done
     # This is to work around the fact that CocoaPods wants to set up the master CocoaPods specs
     # repo on pod lib lint, which takes several minutes on CircleCI. Without dependancies, this
     # isn't a nescessary step. We can point it at any other (smaller) Git repo to speed up this

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   pre:
     - brew update 1> /dev/null 2> /dev/null
-    - brew outdated carthage || brew upgrade carthage
+    - brew outdated carthage || (brew uninstall carthage --force; HOMEBREW_NO_AUTO_UPDATE=1 brew install carthage --force-bottle)
     - gem install bundler
 
 test:


### PR DESCRIPTION
- Gather build output from `xcodebuild` via Carthage in CircleCI run reports.

- When a newer version of Carthage is available from Homebrew, force bottle (pre-compiled executable) installation, rather than attempt to build the Carthage tool on CI with a possibly mismatched or pre-release version of Xcode.

This PR can be retargeted to `master`, in the event that Pull #46 merges first (might as well).