### PR TITLE
Add support for multiplier constraints derived from axis anchors

### DIFF
--- a/Anchorage.xcodeproj/project.pbxproj
+++ b/Anchorage.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		3C2050B71D3B213B00995DF3 /* Anchorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2050B61D3B213B00995DF3 /* Anchorage.swift */; };
 		7A39D6311EB53E1100BDE9C0 /* AnchorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A39D6301EB53E1100BDE9C0 /* AnchorageTests.swift */; };
 		7A39D6331EB53E1100BDE9C0 /* Anchorage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C2050AB1D3B20FD00995DF3 /* Anchorage.framework */; };
+		BBE7C0D71FAB676F00DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE7C0D51FAB65B900DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift */; };
+		BBE7C0D81FAB677500DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE7C0D51FAB65B900DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift */; };
+		BBE7C0D91FAB677600DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE7C0D51FAB65B900DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift */; };
 		CD6A0E6C1EB7CDEF00FFF5DB /* Anchorage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F15462921E56842400C3948D /* Anchorage.framework */; };
 		CD6A0E801EB7CE3A00FFF5DB /* Anchorage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD6A0E771EB7CE3A00FFF5DB /* Anchorage.framework */; };
 		CD71F7A31EB7DD2D008C1CC4 /* AnchorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A39D6301EB53E1100BDE9C0 /* AnchorageTests.swift */; };
@@ -107,6 +110,7 @@
 		7A39D62E1EB53E1100BDE9C0 /* AnchorageTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AnchorageTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A39D6301EB53E1100BDE9C0 /* AnchorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnchorageTests.swift; sourceTree = "<group>"; };
 		7A39D6321EB53E1100BDE9C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BBE7C0D51FAB65B900DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutAnchor+MultiplierConstraints.swift"; sourceTree = "<group>"; };
 		CD6A0E671EB7CDEF00FFF5DB /* AnchorageTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AnchorageTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD6A0E771EB7CE3A00FFF5DB /* Anchorage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Anchorage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD6A0E7F1EB7CE3A00FFF5DB /* Anchorage-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Anchorage-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -231,6 +235,7 @@
 				D469DCB41EB7A904000F3DDD /* Priority.swift */,
 				D401673E1EB7A58D0025DCA5 /* Compatability.swift */,
 				D401673C1EB7A4A30025DCA5 /* Internal.swift */,
+				BBE7C0D51FAB65B900DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift */,
 				3C2050AF1D3B20FD00995DF3 /* Info.plist */,
 			);
 			name = Anchorage;
@@ -613,6 +618,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C2050B71D3B213B00995DF3 /* Anchorage.swift in Sources */,
+				BBE7C0D71FAB676F00DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */,
 				D401673D1EB7A4A30025DCA5 /* Internal.swift in Sources */,
 				D401673F1EB7A58D0025DCA5 /* Compatability.swift in Sources */,
 				D469DCB71EB7A975000F3DDD /* AnchorGroupProvider.swift in Sources */,
@@ -641,6 +647,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD71F7A81EB7DD38008C1CC4 /* Compatability.swift in Sources */,
+				BBE7C0D91FAB677600DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */,
 				CD71F7A51EB7DD38008C1CC4 /* Anchorage.swift in Sources */,
 				CD71F7A61EB7DD38008C1CC4 /* AnchorGroupProvider.swift in Sources */,
 				CD71F7A91EB7DD38008C1CC4 /* Internal.swift in Sources */,
@@ -661,6 +668,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D40167401EB7A6270025DCA5 /* Internal.swift in Sources */,
+				BBE7C0D81FAB677500DACD2D /* NSLayoutAnchor+MultiplierConstraints.swift in Sources */,
 				F154629B1E56846200C3948D /* Anchorage.swift in Sources */,
 				D40167411EB7A6270025DCA5 /* Compatability.swift in Sources */,
 				D469DCB91EB7AB2F000F3DDD /* Priority.swift in Sources */,

--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -141,6 +141,19 @@ class AnchorageTests: XCTestCase {
         XCTAssertEqual(constraint.secondAttribute, .width)
     }
 
+    func testAxisAnchorEqualityWithMultiplier() {
+        let constraint = view1.leadingAnchor == window.trailingAnchor / 2
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, window)
+        XCTAssertEqual(constraint.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .leading)
+        XCTAssertEqual(constraint.secondAttribute, .trailing)
+    }
+
     func testEqualityWithOffsetAndMultiplier() {
         let constraint = view1.widthAnchor == (view2.widthAnchor + 10) / 2
         assertIdentical(constraint.firstItem, view1)
@@ -152,6 +165,19 @@ class AnchorageTests: XCTestCase {
         XCTAssertEqual(constraint.relation, .equal)
         XCTAssertEqual(constraint.firstAttribute, .width)
         XCTAssertEqual(constraint.secondAttribute, .width)
+    }
+
+    func testAxisAnchorEqualityWithOffsetAndMultiplier() {
+        let constraint = view1.trailingAnchor == (window.centerXAnchor + 10) / 2
+        assertIdentical(constraint.firstItem, view1)
+        assertIdentical(constraint.secondItem, window)
+        XCTAssertEqual(constraint.constant, 10, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(constraint.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(constraint.relation, .equal)
+        XCTAssertEqual(constraint.firstAttribute, .trailing)
+        XCTAssertEqual(constraint.secondAttribute, .centerX)
     }
 
     func testEqualityWithPriorityConstant() {

--- a/Source/Anchorage.swift
+++ b/Source/Anchorage.swift
@@ -59,11 +59,11 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 }
 
 @discardableResult public func == (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    return finalize(constraint: lhs.constraint(equalTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func == (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
@@ -122,11 +122,11 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 }
 
 @discardableResult public func <= (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    return finalize(constraint: lhs.constraint(lessThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func <= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
@@ -183,11 +183,11 @@ extension NSLayoutAnchor: LayoutAnchorType {}
 }
 
 @discardableResult public func >= (lhs: NSLayoutXAxisAnchor, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutYAxisAnchor, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> NSLayoutConstraint {
-    return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, constant: rhs.constant), withPriority: rhs.priority)
+    return finalize(constraint: lhs.constraint(greaterThanOrEqualTo: rhs.anchor!, multiplier: rhs.multiplier, constant: rhs.constant), withPriority: rhs.priority)
 }
 
 @discardableResult public func >= (lhs: NSLayoutDimension, rhs: LayoutExpression<NSLayoutDimension, CGFloat>) -> NSLayoutConstraint {
@@ -275,11 +275,71 @@ infix operator ~: PriorityPrecedence
     return expr
 }
 
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: NSLayoutXAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+    return LayoutExpression(anchor: Optional<NSLayoutXAxisAnchor>.some(lhs), constant: 0.0, multiplier: CGFloat(rhs))
+}
+
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: NSLayoutXAxisAnchor) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+    return LayoutExpression(anchor: rhs, constant: 0.0, multiplier: CGFloat(lhs))
+}
+
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+    var expr = lhs
+    expr.multiplier *= CGFloat(rhs)
+    return expr
+}
+
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+    var expr = rhs
+    expr.multiplier *= CGFloat(lhs)
+    return expr
+}
+
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: NSLayoutYAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: CGFloat(rhs))
+}
+
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: NSLayoutYAxisAnchor) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+    return LayoutExpression(anchor: rhs, constant: 0.0, multiplier: CGFloat(lhs))
+}
+
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+    var expr = lhs
+    expr.multiplier *= CGFloat(rhs)
+    return expr
+}
+
+@discardableResult public func * <T: BinaryFloatingPoint>(lhs: T, rhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+    var expr = rhs
+    expr.multiplier *= CGFloat(lhs)
+    return expr
+}
+
 @discardableResult public func / <T: BinaryFloatingPoint>(lhs: NSLayoutDimension, rhs: T) -> LayoutExpression<NSLayoutDimension, CGFloat> {
     return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: 1.0 / CGFloat(rhs))
 }
 
 @discardableResult public func / <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutDimension, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutDimension, CGFloat> {
+    var expr = lhs
+    expr.multiplier /= CGFloat(rhs)
+    return expr
+}
+
+@discardableResult public func / <T: BinaryFloatingPoint>(lhs: NSLayoutXAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: 1.0 / CGFloat(rhs))
+}
+
+@discardableResult public func / <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutXAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutXAxisAnchor, CGFloat> {
+    var expr = lhs
+    expr.multiplier /= CGFloat(rhs)
+    return expr
+}
+
+@discardableResult public func / <T: BinaryFloatingPoint>(lhs: NSLayoutYAxisAnchor, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
+    return LayoutExpression(anchor: lhs, constant: 0.0, multiplier: 1.0 / CGFloat(rhs))
+}
+
+@discardableResult public func / <T: BinaryFloatingPoint>(lhs: LayoutExpression<NSLayoutYAxisAnchor, CGFloat>, rhs: T) -> LayoutExpression<NSLayoutYAxisAnchor, CGFloat> {
     var expr = lhs
     expr.multiplier /= CGFloat(rhs)
     return expr

--- a/Source/NSLayoutAnchor+MultiplierConstraints.swift
+++ b/Source/NSLayoutAnchor+MultiplierConstraints.swift
@@ -1,0 +1,88 @@
+//
+//  NSLayoutAnchor+MultiplierConstraints.swift
+//  Anchorage
+//
+//  Created by Aleksandr Gusev on 7/21/17.
+//
+//  Copyright 2016 Raizlabs and other contributors
+//  http://raizlabs.com/
+//
+//  Permission is hereby granted, free of charge, to any person obtaining
+//  a copy of this software and associated documentation files (the
+//  Software"), to deal in the Software without restriction, including
+//  without limitation the rights to use, copy, modify, merge, publish,
+//  distribute, sublicense, and/or sell copies of the Software, and to
+//  permit persons to whom the Software is furnished to do so, subject to
+//  the following conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+//  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+//  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+//  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import UIKit
+
+extension NSLayoutXAxisAnchor {
+    func constraint(equalTo anchor: NSLayoutXAxisAnchor,
+                    multiplier m: CGFloat,
+                    constant c: CGFloat = 0.0) -> NSLayoutConstraint {
+        let constraint = self.constraint(equalTo: anchor, constant: c)
+        return constraint.constraint(multiplier: m)
+    }
+
+    func constraint(greaterThanOrEqualTo anchor: NSLayoutXAxisAnchor,
+                    multiplier m: CGFloat,
+                    constant c: CGFloat = 0.0) -> NSLayoutConstraint {
+        let constraint = self.constraint(greaterThanOrEqualTo: anchor, constant: c)
+        return constraint.constraint(multiplier: m)
+    }
+
+    func constraint(lessThanOrEqualTo anchor: NSLayoutXAxisAnchor,
+                    multiplier m: CGFloat,
+                    constant c: CGFloat = 0.0) -> NSLayoutConstraint {
+        let constraint = self.constraint(lessThanOrEqualTo: anchor, constant: c)
+        return constraint.constraint(multiplier: m)
+    }
+}
+
+extension NSLayoutYAxisAnchor {
+    func constraint(equalTo anchor: NSLayoutYAxisAnchor,
+                    multiplier m: CGFloat,
+                    constant c: CGFloat = 0.0) -> NSLayoutConstraint {
+        let constraint = self.constraint(equalTo: anchor, constant: c)
+        return constraint.constraint(multiplier: m)
+    }
+
+    func constraint(greaterThanOrEqualTo anchor: NSLayoutYAxisAnchor,
+                    multiplier m: CGFloat,
+                    constant c: CGFloat = 0.0) -> NSLayoutConstraint {
+        let constraint = self.constraint(greaterThanOrEqualTo: anchor, constant: c)
+        return constraint.constraint(multiplier: m)
+    }
+
+    func constraint(lessThanOrEqualTo anchor: NSLayoutYAxisAnchor,
+                    multiplier m: CGFloat,
+                    constant c: CGFloat = 0.0) -> NSLayoutConstraint {
+        let constraint = self.constraint(lessThanOrEqualTo: anchor, constant: c)
+        return constraint.constraint(multiplier: m)
+    }
+}
+
+private extension NSLayoutConstraint {
+    func constraint(multiplier: CGFloat) -> NSLayoutConstraint {
+        return NSLayoutConstraint(item: firstItem!,
+                                  attribute: firstAttribute,
+                                  relatedBy: relation,
+                                  toItem: secondItem,
+                                  attribute: secondAttribute,
+                                  multiplier: multiplier,
+                                  constant: constant)
+    }
+}
+


### PR DESCRIPTION
The `NSLayoutConstraint` API allows for creation of constraints with both
offset and multiplier not only between dimensions (width & height), but also
between axial attributes (left, right, leading, trailing, center). Such
constraints are useful for relative positioning of a subview within a parent
view (e.g. position subview so that it's center point is located in the middle
of its parent view on horizontal axis and at 25% of the parent view's height
on the vertical axis).

For some reason, Apple chose not to support creation of such constraints through
the base `NSLayoutAnchor` API, and multiplier constraints are only exposed through the
`NSLayoutDimension` subclass. Since Anchorage is wrapping the `NSLayoutAnchor` API, it
also cannot be used to create these axial multiplier constraints.

This PR introduces methods for creating multiplier constraints between axis anchors
in extensions on `NSLayoutXAxisAnchor` and `NSLayoutYAxisAnchor`, as well as corresponding
new functions to the Anchorage API.