### PR TITLE
Support nested batches (without combining their constraints)

### DIFF
--- a/AnchorageTests/AnchorageTests.swift
+++ b/AnchorageTests/AnchorageTests.swift
@@ -588,6 +588,51 @@ class AnchorageTests: XCTestCase {
         XCTAssertEqual(height.firstAttribute, .height)
         XCTAssertEqual(height.secondAttribute, .height)
     }
+    
+    func testNestedBatchConstraints() {
+        var nestedConstraints: [NSLayoutConstraint] = []
+        let constraints = Anchorage.batch {
+            view1.widthAnchor == view2.widthAnchor
+            nestedConstraints = Anchorage.batch(active: false) {
+                view1.heightAnchor == view2.heightAnchor / 2 ~ .low
+            }
+            view1.leadingAnchor == view2.leadingAnchor
+        }
+        
+        let width = constraints[0]
+        let leading = constraints[1]
+        let height = nestedConstraints[0]
+        
+        assertIdentical(width.firstItem, view1)
+        assertIdentical(width.secondItem, view2)
+        XCTAssertEqual(width.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(width.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(width.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(width.isActive)
+        XCTAssertEqual(width.relation, .equal)
+        XCTAssertEqual(width.firstAttribute, .width)
+        XCTAssertEqual(width.secondAttribute, .width)
+        
+        assertIdentical(height.firstItem, view1)
+        assertIdentical(height.secondItem, view2)
+        XCTAssertEqual(height.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(height.multiplier, 0.5, accuracy: cgEpsilon)
+        XCTAssertEqual(height.priority.rawValue, TestPriorityLow.rawValue, accuracy: fEpsilon)
+        XCTAssertFalse(height.isActive)
+        XCTAssertEqual(height.relation, .equal)
+        XCTAssertEqual(height.firstAttribute, .height)
+        XCTAssertEqual(height.secondAttribute, .height)
+        
+        assertIdentical(leading.firstItem, view1)
+        assertIdentical(leading.secondItem, view2)
+        XCTAssertEqual(leading.constant, 0, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.multiplier, 1, accuracy: cgEpsilon)
+        XCTAssertEqual(leading.priority.rawValue, TestPriorityRequired.rawValue, accuracy: fEpsilon)
+        XCTAssertTrue(leading.isActive)
+        XCTAssertEqual(leading.relation, .equal)
+        XCTAssertEqual(leading.firstAttribute, .leading)
+        XCTAssertEqual(leading.secondAttribute, .leading)
+    }
 
 }
 

--- a/Source/Anchorage.swift
+++ b/Source/Anchorage.swift
@@ -397,7 +397,6 @@ infix operator ~: PriorityPrecedence
 
 /// Any Anchorage constraints created inside the passed closure are returned in the array.
 ///
-/// - Precondition: Can't be called inside or simultaneously with another batch. Batches cannot be nested.
 /// - Parameter closure: A closure that runs some Anchorage expressions.
 /// - Returns: An array of new, active `NSLayoutConstraint`s.
 @discardableResult public func batch(_ closure: () -> Void) -> [NSLayoutConstraint] {
@@ -406,18 +405,15 @@ infix operator ~: PriorityPrecedence
 
 /// Any Anchorage constraints created inside the passed closure are returned in the array.
 ///
-/// - Precondition: Can't be called inside or simultaneously with another batch. Batches cannot be nested.
 /// - Parameter active: Whether the created constraints should be active when they are returned.
 /// - Parameter closure: A closure that runs some Anchorage expressions.
 /// - Returns: An array of new `NSLayoutConstraint`s.
 public func batch(active: Bool, closure: () -> Void) -> [NSLayoutConstraint] {
-    precondition(currentBatch == nil)
-    defer {
-        currentBatch = nil
-    }
-
     let batch = ConstraintBatch()
-    currentBatch = batch
+    batches.append(batch)
+    defer {
+        batches.removeLast()
+    }
 
     closure()
 

--- a/Source/Internal.swift
+++ b/Source/Internal.swift
@@ -312,7 +312,7 @@ internal struct ConstraintBuilder {
 
 // MARK: - Batching
 
-internal var currentBatch: ConstraintBatch?
+internal var batches: [ConstraintBatch] = []
 
 internal class ConstraintBatch {
 
@@ -333,7 +333,7 @@ internal class ConstraintBatch {
 ///
 /// - Parameter closure: The work to perform inside of a batch
 internal func performInBatch(closure: () -> Void) {
-    if currentBatch == nil {
+    if batches.isEmpty {
         batch(closure)
     }
     else {
@@ -351,8 +351,8 @@ internal func finalize(constraint: NSLayoutConstraint, withPriority priority: Pr
 
     constraint.priority = priority.value
 
-    if let currentBatch = currentBatch {
-        currentBatch.add(constraint: constraint)
+    if let lastBatch = batches.last {
+        lastBatch.add(constraint: constraint)
     }
     else {
         constraint.isActive = true


### PR DESCRIPTION
I have a feeling that you guys may have already considered this, but I thought I'd suggest this nested constraint batch implementation. IDK how this fits in conceptually, so treat this as a proposal.

Right now Anchorage does not support nested batches at all and trying to create one while another batch is already in place is considered programming error. However, after I started using Anchorage extensively, I've found that this gets in the way every now and then, with higher-level code suddenly having to care/know about whether lower-level code is using batches to set up its constraints or not. At the same time, a naïve nested batch implementation is trivial to implement. Which is what this PR is about.

Instead of keeping a global reference to a single (optional) active batch, I've expanded the concept to store a stack of active batches in an array, with newly created constraints being recorded into the most recent batch in the global “stack”. Now, this implementation keeps all the nested batches completely isolated from each other (i. e. constraints added to any of the nested batches would not appear and would not be affected by the `active` flag of the batches higher up in the batch stack). It feels reasonably intuitive to me, but I guess others might feel different.

Thoughts?