### PR TITLE
Fix CI build for test-swift-5 and test-swift-4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ commands:
         default: "5.0"
       ios-version:
         type: string
-        default: "13.5"
+        default: "14.2"
       tvos-version:
         type: string
         default: "13.4"


### PR DESCRIPTION
Observed issue:

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ platform:iOS Simulator, OS:13.5, name:iPhone 8 }

	The requested device could not be found because no available devices matched the request
```

I updated the OS version to 14.2, since this iOS simulator version is available in the list:

```
Available destinations for the "AnchorageDemo" scheme:
		{ platform:iOS Simulator, id:31FEB6C5-66B3-4450-A74B-ED7269F74731, OS:13.7, name:iPad (7th generation) }
		{ platform:iOS Simulator, id:DC552CC0-6935-4F27-88DF-744AA00C3C00, OS:14.2, name:iPad (8th generation) }
		{ platform:iOS Simulator, id:A4A8DF9A-4A4A-4BCF-B9A9-3E48A2AFFEE2, OS:13.7, name:iPad Air (3rd generation) }
		{ platform:iOS Simulator, id:DE78C91E-F524-4CE7-B8A8-01DEC73FB86B, OS:14.2, name:iPad Air (4th generation) }
		{ platform:iOS Simulator, id:BBEEFF3D-1396-4B52-8D34-D133C42C4723, OS:13.7, name:iPad Pro (9.7-inch) }
		{ platform:iOS Simulator, id:11A7A125-0D4F-415A-AF0D-CE6BE63FF149, OS:14.2, name:iPad Pro (9.7-inch) }
		{ platform:iOS Simulator, id:8571B3DA-3EBD-4E0C-9753-48BE1162D85D, OS:13.7, name:iPad Pro (11-inch) (2nd generation) }
		{ platform:iOS Simulator, id:A1F99B6A-E349-443A-AA29-E4A414974580, OS:14.2, name:iPad Pro (11-inch) (2nd generation) }
		{ platform:iOS Simulator, id:F6A6CA82-1CD6-4225-B690-30934C2A3C57, OS:13.7, name:iPad Pro (12.9-inch) (4th generation) }
		{ platform:iOS Simulator, id:D9FC54EB-DC05-4F14-991E-9BA4F1CE5524, OS:14.2, name:iPad Pro (12.9-inch) (4th generation) }
		{ platform:iOS Simulator, id:F07C8454-A674-46AC-A811-9FA197AFB09A, OS:13.7, name:iPhone 8 }
		{ platform:iOS Simulator, id:D8B0C796-AFBD-4FF0-B7E4-3223DC629E16, OS:14.2, name:iPhone 8 }
		{ platform:iOS Simulator, id:AB7B0A4C-680A-496E-BDDF-8ABA849E3BA2, OS:13.7, name:iPhone 8 Plus }
		{ platform:iOS Simulator, id:0C4E1F4E-3812-4350-8252-6903C2F24DB5, OS:14.2, name:iPhone 8 Plus }
		{ platform:iOS Simulator, id:7140ECD7-3F0B-4A16-912D-D09354D445F4, OS:13.7, name:iPhone 11 }
		{ platform:iOS Simulator, id:EC9053AC-BE93-464F-93AB-FF4A5AF11B98, OS:14.2, name:iPhone 11 }
		{ platform:iOS Simulator, id:6F906FF4-B912-449D-8854-EF92FFE6EC27, OS:13.7, name:iPhone 11 Pro }
		{ platform:iOS Simulator, id:49F24D56-5320-40E6-A4E3-3DFC9C03ED57, OS:14.2, name:iPhone 11 Pro }
		{ platform:iOS Simulator, id:81F83D7A-01C2-4FD5-A34C-DEB98040C1D9, OS:13.7, name:iPhone 11 Pro Max }
		{ platform:iOS Simulator, id:286B571D-D96D-476D-BA09-0C3E00DE2CF4, OS:14.2, name:iPhone 11 Pro Max }
		{ platform:iOS Simulator, id:B5C0A451-D0B1-40A0-865D-461B54252B05, OS:14.2, name:iPhone 12 }
		{ platform:iOS Simulator, id:F9447751-0E84-4C39-981C-F6FD255BE51E, OS:14.2, name:iPhone 12 Pro }
		{ platform:iOS Simulator, id:8F082E03-D641-45DF-AE70-CDA22375F4C7, OS:14.2, name:iPhone 12 Pro Max }
		{ platform:iOS Simulator, id:D35B712C-8F0A-43A4-9949-52342C9D7BFC, OS:14.2, name:iPhone 12 mini }
		{ platform:iOS Simulator, id:C9CC4730-FD15-43BA-AF27-EECFD1834B62, OS:13.7, name:iPhone SE (2nd generation) }
		{ platform:iOS Simulator, id:9711AB26-19C7-4F4E-9646-3827E2D14735, OS:14.2, name:iPhone SE (2nd generation) }
		{ platform:iOS Simulator, id:4130D0D8-54CC-40D5-904F-C03D5A79AB19, OS:14.2, name:iPod touch (7th generation) }
```